### PR TITLE
fix: Ensure health check only matches whole word 'healthy'

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           set -eux
           docker compose up --build --detach --timeout 60
           sleep 60
-          docker inspect --format='{{.State.Health.Status}}' cover-letter-writer | grep 'healthy'
+          docker inspect --format='{{.State.Health.Status}}' cover-letter-writer | grep -w 'healthy'
         working-directory: tests
       # Stop and remove the test container image
       - name: Stop and remove container image


### PR DESCRIPTION
Fixes a bug where the health check in the test workflow could incorrectly match substrings of 'healthy', leading to false positives. The grep command now uses the `-w` flag to match only the whole word 'healthy'.